### PR TITLE
Arreglos varios del codigo del cliente y el servidor

### DIFF
--- a/game/client/headers/Client.h
+++ b/game/client/headers/Client.h
@@ -7,10 +7,6 @@
 #include "MapUi.h"
 #include "Protocol.h"
 
-
-typedef std::chrono::time_point<std::chrono::system_clock> chrono;
-typedef std::chrono::duration<double, std::milli> duration;
-
 class Client {
 private:
     Protocol protocol;
@@ -22,28 +18,12 @@ private:
 
 
 public:
-    duration simDeltaTime(chrono &t1, chrono &t2) {
-        t2= std::chrono::system_clock::now();
-        auto delta= t2 - t1;
-        t1 = t2;
-
-        return delta;
-    }
-
-    void sleep(const chrono &t1, const chrono &t2, duration &delta) const {
-        delta = t2 - t1;
-        if (delta.count() < (1.0 / 30))
-            usleep((1.0 / 30) - delta.count());
-    }
-
     Client(const std::string& hostname, const std::string& servicename, Renderer &rnd);
     void run();
 
     void sendToServer();
 
     void receiveOfServer();
-
-    Request* createEvent();
 
     void ProcessInput();
 

--- a/game/client/headers/Protocol.h
+++ b/game/client/headers/Protocol.h
@@ -32,6 +32,7 @@ public:
     void send(int command, const std::vector<uint16_t>& vector);
 
     std::pair<coordenada_t, std::vector<uint8_t>> receiveTerrain();
+    void close();
 };
 
 

--- a/game/client/sources/Client.cpp
+++ b/game/client/sources/Client.cpp
@@ -1,8 +1,11 @@
 #include <thread>
 #include <utility>
+#include <sstream>
 #include "SDL2pp/SDL2pp.hh"
 #include "../headers/Client.h"
 #include "../headers/CreateLightInfantry.h"
+#include "common/headers/Chronometer.h"
+#include "common/headers/Constantes.h"
 
 using namespace SDL2pp;
 
@@ -18,66 +21,64 @@ void Client::run() {
     std::thread threadSend(&Client::sendToServer, this);
 
 
-    auto t1 = std::chrono::system_clock::now();
+    Chronometer chronometer;
     while(running) {
+        chronometer.tick();
+
         ProcessInput();
         update();
         renderer();
-        auto t2 = std::chrono::system_clock::now();
-        auto delta = simDeltaTime(t1, t2);
-        sleep(t1, t2, delta);
+        uint64_t delta = chronometer.tack();
+        if (delta < GAME_LOOP_RATE)
+            usleep(GAME_LOOP_RATE - delta);
     }
+    // Si algo lanza excepción antes, leakeas estos hilos. Falta RAII en estos recursos. Que sean atributos del cliente o de otro 
+    // objeto RAII que los libere en su destructor
+    sendQueue.stop();
     threadReceive.join();
     threadSend.join();
 }
 
 void Client::ProcessInput() {
-    Request *event = createEvent();
-    if(event != nullptr) {
-        sendQueue.push(event);
-    }
-}
-
-Request* Client::createEvent() {
     SDL_Event event;
     Request* req = nullptr;
-    SDL_PollEvent(&event);
-    switch (event.type) {
-        case SDL_QUIT:
-            running = false;
-            break;
-        case SDL_KEYDOWN:
-            switch (event.key.keysym.sym) {
-                case SDLK_a:
-                    int x = -1 ,y = -1;
-                    SDL_GetMouseState(&x, &y);
-                    Request *unit = new CreateLightInfantry(x / 16, y / 16);
-                    req = unit;
-                    break;
-            }
-        case SDL_MOUSEBUTTONUP:
-            if(event.button.button ==  SDL_BUTTON_RIGHT) {
-                Request* request;
-                int x, y;
-                x = event.button.x;
-                y = event.button.y;
-                request = mapUi.moveCharacter(x / 16, y / 16, clientId);
-                req = request;
-            }
-            else if(event.button.button == SDL_BUTTON_LEFT) {
-                Request* r;
-                int x, y;
-                x = event.button.x;
-                y = event.button.y;
-                r =  mapUi.mouseEvent(x, y, clientId);
-                req = r;
+    while (running && SDL_PollEvent(&event)) {
+        switch (event.type) {
+            case SDL_QUIT:
+                std::cout << "QUIT" << std::endl;
+                running = false;
                 break;
-            }
-        default:
-            break;
+            case SDL_KEYDOWN:
+                switch (event.key.keysym.sym) {
+                    case SDLK_a:
+                        int x = -1 ,y = -1;
+                        SDL_GetMouseState(&x, &y);
+                        Request *unit = new CreateLightInfantry(x / 16, y / 16);
+                        sendQueue.push(unit);
+                        break;
+                }
+            case SDL_MOUSEBUTTONUP:
+                if(event.button.button ==  SDL_BUTTON_RIGHT) {
+                    Request* request;
+                    int x, y;
+                    x = event.button.x;
+                    y = event.button.y;
+                    request = mapUi.moveCharacter(x / 16, y / 16, clientId);
+                    sendQueue.push(request);
+                }
+                else if(event.button.button == SDL_BUTTON_LEFT) {
+                    Request* r;
+                    int x, y;
+                    x = event.button.x;
+                    y = event.button.y;
+                    r =  mapUi.mouseEvent(x, y, clientId);
+                    sendQueue.push(r);
+                    break;
+                }
+            default:
+                break;
+        }
     }
-
-    return req;
 }
 
 void Client::update() {
@@ -88,20 +89,34 @@ void Client::update() {
 }
 
 void Client::sendToServer() {
-    while(running) {
-        std::vector<uint16_t> data;
-        Request *event = this->sendQueue.pop();
-        if (event != nullptr) {
-            data = event->getData();
-            protocol.send(event->getCommand(), data);
+    try {
+         while(running) {
+            std::vector<uint16_t> data;
+            Request *event = this->sendQueue.pop();
+            if (event != nullptr) {
+                data = event->getData();
+                protocol.send(event->getCommand(), data);
+            }
         }
+    } catch (std::exception &e) {
+        std::ostringstream oss;
+        oss << "[sender]: " << e.what() << std::endl;
+        // Para evitar RC en el flujo de error
+        std::cout << oss.str();
     }
 }
 
 void Client::receiveOfServer() {
-    while(running) {
-        Response *response = protocol.recvResponse();
-        this->recvQueue.push(response);
+    try {
+        while(running) {
+            Response *response = protocol.recvResponse();
+            this->recvQueue.push(response);
+        }
+    } catch (std::exception &e) {
+        std::ostringstream oss;
+        oss << "[receiver]: " << e.what() << std::endl;
+        // Para evitar RC en el flujo de error
+        std::cout << oss.str();
     }
 }
 

--- a/game/client/sources/ClientMain.cpp
+++ b/game/client/sources/ClientMain.cpp
@@ -1,12 +1,27 @@
 #include "SDL2pp/SDL2pp.hh"
 #include "../headers/Client.h"
+#include <sstream>
 
 using namespace  SDL2pp;
 int main(int argc, char* argv[]) {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <hostname> <service>" << std::endl;
+    return -1;
+  }
+
+  try{
     SDL sdl(SDL_INIT_VIDEO);
     Window window("Client", SDL_WINDOWPOS_UNDEFINED,
                   SDL_WINDOWPOS_UNDEFINED,640, 480, SDL_WINDOW_RESIZABLE);
     Renderer render(window, -1, SDL_RENDERER_ACCELERATED);
     Client client(argv[1], argv[2], render);
     client.run();
+  } catch (std::exception &e) {
+    std::ostringstream oss;
+    oss << "[main]: " << e.what() << std::endl;
+    // Para evitar RC en el flujo de error
+    std::cerr << oss.str();
+    return -1;
+  }
+  return 0;
 }

--- a/game/client/sources/Protocol.cpp
+++ b/game/client/sources/Protocol.cpp
@@ -127,3 +127,8 @@ std::pair<coordenada_t, std::vector<uint8_t>> Protocol::receiveTerrain() {
 }
 
 
+
+void Protocol::close() {
+    this->skt.shutdown(SHUT_RDWR);
+    this->skt.close();
+}

--- a/game/common/headers/BlockingQueue.h
+++ b/game/common/headers/BlockingQueue.h
@@ -5,6 +5,7 @@
 #include <queue>
 #include <condition_variable>
 #include <atomic>
+#include <exception>
 
 template<class T>
 class BlockingQueue {
@@ -26,7 +27,7 @@ public:
         std::unique_lock<std::mutex> uniqueLock(mutex);
         while (data.empty()) {
             if (closed)
-                return {};
+                throw std::runtime_error("cierro queue");
             conditionVariable.wait(uniqueLock);
         }
 

--- a/game/common/headers/Chronometer.h
+++ b/game/common/headers/Chronometer.h
@@ -5,8 +5,8 @@ class Chronometer {
 public:
     Chronometer();
     ~Chronometer() = default;
-
-    uint64_t now();
+    void tick();
+    uint64_t tack();
 private:
     std::chrono::time_point<std::chrono::system_clock> start;
 };

--- a/game/common/headers/Constantes.h
+++ b/game/common/headers/Constantes.h
@@ -64,6 +64,7 @@ typedef std::pair<int, int> coordenada_t;
 #define HOUSE_HARKONNEN 1
 #define HOUSE_ORDOS 2
 
-#define GAME_LOOP_RATE 111111
+// 1000000 us / 20
+#define GAME_LOOP_RATE 50000
 
 #endif //TP_FINAL_DUNE_GRUPO_1_CONSTANTES_H

--- a/game/common/sources/Chronometer.cpp
+++ b/game/common/sources/Chronometer.cpp
@@ -1,12 +1,15 @@
 #include "common/headers/Chronometer.h"
 
 using _clock = std::chrono::system_clock;
-using _duration = std::chrono::microseconds;
 
 Chronometer::Chronometer(): start(_clock::now()) {}
 
-uint64_t Chronometer::now() {
+void Chronometer::tick() {
+    start = _clock::now();
+}
+
+uint64_t Chronometer::tack() {
     auto current = _clock::now();
-    _duration diff = std::chrono::duration_cast<_duration>(current - this->start);
+    auto diff = std::chrono::duration_cast<std::chrono::microseconds>(current - this->start);
     return diff.count();
 }

--- a/game/common/sources/Socket.cpp
+++ b/game/common/sources/Socket.cpp
@@ -89,8 +89,8 @@ Socket::Socket(int skt) {
 
 Socket::~Socket() {
     if (not this->closed) {
-        ::shutdown(this->skt, 2);
         ::close(this->skt);
+        this->closed = true;
     }
 }
 int Socket::recvsome(void *data, unsigned int sz) {

--- a/game/server/headers/model/Server.h
+++ b/game/server/headers/model/Server.h
@@ -33,6 +33,7 @@ private:
 public:
 
     Server(const std::string &host);
+    ~Server();
     // Gameloop
     void run();
 

--- a/game/server/headers/model/ServerProtocol.h
+++ b/game/server/headers/model/ServerProtocol.h
@@ -4,6 +4,7 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <atomic>
 
 #include "common/headers/Socket.h"
 #include "common/headers/Entity.h"
@@ -12,7 +13,7 @@
 class ServerProtocol {
 private:
     Socket socket;
-    bool socket_closed;
+    std::atomic<bool> socket_closed;
 
 public:
     explicit ServerProtocol(const std::string& host);

--- a/game/server/sources/model/ServerProtocol.cpp
+++ b/game/server/sources/model/ServerProtocol.cpp
@@ -14,9 +14,11 @@ Socket ServerProtocol::accept() {
 }
 
 void ServerProtocol::shutdown(int how) {
-    socket.shutdown(how);
-    socket.close();
-    socket_closed = true;
+    if (!this->socket_closed) {    
+        socket.shutdown(how);
+        socket.close();
+        socket_closed = true;
+    }
 }
 
 int ServerProtocol::commandReceive() {

--- a/game/server/sources/model/ThClient.cpp
+++ b/game/server/sources/model/ThClient.cpp
@@ -11,15 +11,19 @@ ThClient::ThClient(Socket &&peer, ProtectedQueue<ServerEvent *> &protectedQueue,
         protocol(std::move(peer)), playerId(id), rows(rows), columns(columns), terrain(std::move(terrain)) {}
 
 void ThClient::run() {
-    protocol.assignPlayerId(playerId);
-    protocol.sendTerrain(rows, columns, std::move(terrain));
+    try {
+        protocol.assignPlayerId(playerId);
+        protocol.sendTerrain(rows, columns, std::move(terrain));
 
-    while (keep_talking) {
-        int command = protocol.commandReceive();
-        manageCommand(command);
+        while (keep_talking) {
+            int command = protocol.commandReceive();
+            manageCommand(command);
+        }
+
+        is_running = false;
+    } catch (std::exception &e) {
+        std::cerr << "[hilo thclient]: " << e.what() << std::endl;
     }
-
-    is_running = false;
 }
 
 void ThClient::stop() {

--- a/game/server/sources/model/server_main.cpp
+++ b/game/server/sources/model/server_main.cpp
@@ -1,13 +1,20 @@
 #include "server/headers/model/Server.h"
-
+#include <sstream>
 int main(int argc, char* argv[]) {
-    if (argc > 0) {
-        Server server(argv[1]);
+    if (argc != 2) {
+        std::cerr << "Usage: " << argv[0] << " <port>" << std::endl;
+        return -1;
+    } 
+    Server server(argv[1]);
 
-        try {
-            server.run();
-        } catch(const std::exception &e) {
-            return 1;
-        }
+    try {
+        server.run();
+    } catch(const std::exception &e) {
+        std::ostringstream oss;
+        oss << "[main]: " << e.what() << std::endl;
+        // Para evitar RC en el flujo de error
+        std::cerr << oss.str();
+        return -1;
     }
+    return 0;
 }


### PR DESCRIPTION
* Fix del uso del chronometer en el gameloop del cliente y del server (el cliente comparaba segundos con milisegundos, y
en el server lo simplifiqué para que no se compliquen que no les queda tiempo)

* agrego manejo de excepciones en todos los hilos (muy mal que no lo hayan hecho)

* agrego excepciones y shutdowns de objetos que traban algunos hilos al hacer un join

El server igual está fallando al cerrar con la Q debido a un shutdown inválido. Revisar y corregir (les queda de tarea)